### PR TITLE
Explicitely set the brush to transparent before drawing the anchor alarm's circle.

### DIFF
--- a/src/Alarm.cpp
+++ b/src/Alarm.cpp
@@ -105,6 +105,7 @@ public:
                        m_Radius/1853.0/60.0,
                        m_Longitude);
         
+        dc.SetBrush(*wxTRANSPARENT_BRUSH);
         if(m_bEnabled) {
             if(m_bFired)
                 dc.SetPen(wxPen(*wxRED, 2));


### PR DESCRIPTION
With wxGTK 3.0.4 compiled against gtk 3.22, the circle would
come filled with red on my system.